### PR TITLE
make tests run from pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: python
+python:
+  - "3.6.7"
+env:
+  global:
+    - PIPENV_VENV_IN_PROJECT=1
+    - PIPENV_IGNORE_VIRTUALENVS=1
+install:
+  - "pip install pipenv"
+  - "pipenv install --dev --deploy"
+script:
+  - "pipenv run pytest"

--- a/Makefile
+++ b/Makefile
@@ -14,3 +14,6 @@ oc_cluster_train:
 		--param CEPH_SECRET=${CEPH_SECRET} \
 		--param CEPH_ENDPOINT=${CEPH_ENDPOINT} \
 		--param CEPH_BUCKET=${CEPH_BUCKET}
+
+test:
+	pipenv run pytest

--- a/Pipfile
+++ b/Pipfile
@@ -5,6 +5,7 @@ name = "pypi"
 
 [dev-packages]
 ipython = "*"
+pytest = "*"
 
 [packages]
 "boto3" = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "32238e3ecd2483b0b7852266779819c716d9d92b4bdb7061915c54187b39df40"
+            "sha256": "87676b08c8dbf1c2e059e5fe295e9f15c736a7c430d9e593df4b30d461662606"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -25,18 +25,18 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:3533ae8c998d85df4df4a01c1b33d64de861992ee06bd70cd02ff3533adb8b46",
-                "sha256:4adfd7fc14417e925398d5e5df3a3050e74a14b13e17fab5f61bee72a87c6ee4"
+                "sha256:1edb2ff716c2f840d1519f71f041489ed6bd1cf23dfac7a14d2910ebaf94499e",
+                "sha256:4d0efc0bf7cc22fa45a4f4614e53a8bcece142a14f9b88db1cc7d50c01b12280"
             ],
             "index": "pypi",
-            "version": "==1.9.63"
+            "version": "==1.9.64"
         },
         "botocore": {
             "hashes": [
-                "sha256:3b765835d30f192f9f60b17f48573602e972cec3233868485b43a41514ad8f28",
-                "sha256:93224e103a227dc7e3bdf7742f66081b2a99f0965adce790474327f41f83b2a7"
+                "sha256:85291fff27fbf413095be248590bfbaafa32f3fcc45db4d6f2efe2d6f0542978",
+                "sha256:93dc0bea94d0ee785581f297a11311739f51d6ede8c9026a015dc37e6e014694"
             ],
-            "version": "==1.12.63"
+            "version": "==1.12.64"
         },
         "certifi": {
             "hashes": [
@@ -484,6 +484,20 @@
             "markers": "sys_platform == 'darwin'",
             "version": "==0.1.0"
         },
+        "atomicwrites": {
+            "hashes": [
+                "sha256:0312ad34fcad8fac3704d441f7b317e50af620823353ec657a53e981f92920c0",
+                "sha256:ec9ae8adaae229e4f8446952d204a3e4b5fdd2d099f9be3aaf556120135fb3ee"
+            ],
+            "version": "==1.2.1"
+        },
+        "attrs": {
+            "hashes": [
+                "sha256:10cbf6e27dbce8c30807caf056c8eb50917e0eaafe86347671b57254006c3e69",
+                "sha256:ca4be454458f9dec299268d472aaa5a11f67a4ff70093396e1ceae9c76cf4bbb"
+            ],
+            "version": "==18.2.0"
+        },
         "backcall": {
             "hashes": [
                 "sha256:38ecd85be2c1e78f77fd91700c76e14667dc21e2713b63876c0eb901196e01e4",
@@ -520,6 +534,14 @@
             ],
             "version": "==0.13.1"
         },
+        "more-itertools": {
+            "hashes": [
+                "sha256:c187a73da93e7a8acc0001572aebc7e3c69daf7bf6881a2cea10650bd4420092",
+                "sha256:c476b5d3a34e12d40130bc2f935028b5f636df8f372dc2c1c01dc19681b2039e",
+                "sha256:fcbfeaea0be121980e15bc97b3817b5202ca73d0eae185b4550cbfce2a3ebb3d"
+            ],
+            "version": "==4.3.0"
+        },
         "parso": {
             "hashes": [
                 "sha256:35704a43a3c113cce4de228ddb39aab374b8004f4f2407d070b6a2ca784ce8a2",
@@ -542,6 +564,13 @@
             ],
             "version": "==0.7.5"
         },
+        "pluggy": {
+            "hashes": [
+                "sha256:447ba94990e8014ee25ec853339faf7b0fc8050cdc3289d4d71f7f410fb90095",
+                "sha256:bde19360a8ec4dfd8a20dcb811780a30998101f078fc7ded6162f0076f50508f"
+            ],
+            "version": "==0.8.0"
+        },
         "prompt-toolkit": {
             "hashes": [
                 "sha256:c1d6aff5252ab2ef391c2fe498ed8c088066f66bc64a8d5c095bbf795d9fec34",
@@ -557,12 +586,27 @@
             ],
             "version": "==0.6.0"
         },
+        "py": {
+            "hashes": [
+                "sha256:bf92637198836372b520efcba9e020c330123be8ce527e535d185ed4b6f45694",
+                "sha256:e76826342cefe3c3d5f7e8ee4316b80d1dd8a300781612ddbc765c17ba25a6c6"
+            ],
+            "version": "==1.7.0"
+        },
         "pygments": {
             "hashes": [
                 "sha256:6301ecb0997a52d2d31385e62d0a4a4cf18d2f2da7054a5ddad5c366cd39cee7",
                 "sha256:82666aac15622bd7bb685a4ee7f6625dd716da3ef7473620c192c0168aae64fc"
             ],
             "version": "==2.3.0"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:1d131cc532be0023ef8ae265e2a779938d0619bb6c2510f52987ffcba7fa1ee4",
+                "sha256:ca4761407f1acc85ffd1609f464ca20bb71a767803505bd4127d0e45c5a50e23"
+            ],
+            "index": "pypi",
+            "version": "==4.0.1"
         },
         "six": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ app.py:50: FutureWarning: Method .as_matrix will be removed in a future version.
 Name: cluster, Length: 40162, dtype: int32
 ```
 
+## Tests
+
+```
+make test
+```
+
 ## Local build
 
 If you would like to deploy the clustering service locally, you can build the container using [S2I](https://github.com/openshift/source-to-image)

--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -1,53 +1,39 @@
 import pandas as pd
-import sys
-sys.path.append('../')
-
-import storage
 import clustering
 import clustering.config as config
 
-try:
-    train_flag = int(sys.argv[1])
-    inference_flag = int(sys.argv[2])
-    print(train_flag, inference_flag)
-except:
-    raise ValueError("Usage: python test_clustering.py [train_flag] [inference_flag]")
+data = pd.read_csv('tests/test_dataset/train.csv')
+model = {}
 
+def test_training():
+    global model, data
+    index_cols = config.PreprocessSettings.index_cols
+    categorical_cols = config.PreprocessSettings.categorical_cols
+    drop_cols = config.PreprocessSettings.drop_cols
+    n_clusters_low = config.KMeansSettings.n_clusters_low
+    n_clusters_high = config.KMeansSettings.n_clusters_high
+    n_clusters_stepsize = config.KMeansSettings.n_clusters_stepsize
+    n_processes = config.KMeansSettings.n_processes
 
-def load_data():
-    return pd.read_csv('test_dataset/train.csv')
-
-data = load_data()
-
-index_cols = config.PreprocessSettings.index_cols
-categorical_cols = config.PreprocessSettings.categorical_cols
-drop_cols = config.PreprocessSettings.drop_cols
-
-n_clusters_low = config.KMeansSettings.n_clusters_low
-n_clusters_high = config.KMeansSettings.n_clusters_high
-n_clusters_stepsize = config.KMeansSettings.n_clusters_stepsize
-n_processes = config.KMeansSettings.n_processes
-
-if train_flag:
-    print("Training...")
-    #Train - instantiate object
     cluster = clustering.train.Cluster(data, index_cols=index_cols,
                                        categorical_cols=categorical_cols, drop_cols=drop_cols,
-                                       n_clusters_low=n_clusters_low, n_clusters_high=n_clusters_high, 
+                                       n_clusters_low=n_clusters_low, n_clusters_high=n_clusters_high,
                                        n_clusters_stepsize=n_clusters_stepsize, n_processes=n_processes)
 
-    models_to_persist = cluster.train_the_cluster()
+    model = cluster.train_the_cluster()
 
-    storage.write(models_to_persist, '2018-12-12')
+    assert model["prepca_scaler"]
 
-if inference_flag:
-    print("Inference...")
-    #Inference - instantiate object
-    models_to_persist = storage.read('2018-12-12')
+def test_inference():
+    global model, data
+
+    index_cols = config.PreprocessSettings.index_cols
+    categorical_cols = config.PreprocessSettings.categorical_cols
+    drop_cols = config.PreprocessSettings.drop_cols
 
     inf = clustering.inference.Inference(data, index_cols=index_cols,
                               categorical_cols=categorical_cols, drop_cols=drop_cols,
-                              models_dict=models_to_persist)
-    
-    #predict
+                              models_dict=model)
+
     cl_dict = inf.predict()
+    assert len(cl_dict) == 891


### PR DESCRIPTION
```
❯ make test
pipenv run pytest
Loading .env environment variables…
============================================================================== test session starts ==============================================================================
platform darwin -- Python 3.6.7, pytest-4.0.1, py-1.7.0, pluggy-0.8.0
rootdir: /Users/hild/src/aicoe/insights-aiops/aiops-insights-clustering, inifile:
collected 2 items

tests/test_clustering.py ..                                                                                                                                               [100%]

=============================================================================== warnings summary ================================================================================
tests/test_clustering.py::test_training
  /Users/hild/.local/share/virtualenvs/aiops-insights-clustering--0IA9VN8/lib/python3.6/site-packages/sklearn/preprocessing/data.py:625: DataConversionWarning: Data with input dtype uint8, int64, float64 were all converted to float64 by StandardScaler.
    return self.partial_fit(X, y)
  /Users/hild/.local/share/virtualenvs/aiops-insights-clustering--0IA9VN8/lib/python3.6/site-packages/sklearn/base.py:462: DataConversionWarning: Data with input dtype uint8, int64, float64 were all converted to float64 by StandardScaler.
    return self.fit(X, **fit_params).transform(X)

tests/test_clustering.py::test_inference
  /Users/hild/src/aicoe/insights-aiops/aiops-insights-clustering/clustering/inference.py:35: DataConversionWarning: Data with input dtype uint8, int64, float64 were all converted to float64 by StandardScaler.
    df_prepca_scaled = self.prepca_scaler.transform(self.data)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
===================================================================== 2 passed, 3 warnings in 1.31 seconds ======================================================================
```

also added .travis.yml to run tests on travis