### PR TITLE
Add `x-rh-identity` to the POST request header

### DIFF
--- a/server.py
+++ b/server.py
@@ -41,7 +41,13 @@ def index():
             message="Unable to parse input data JSON."
         ), 400
 
-    prediction_worker(input_data, next_service)
+    b64_identity = request.headers.get('x-rh-identity')
+
+    prediction_worker(
+        input_data,
+        next_service,
+        b64_identity
+    )
     APP.logger.info('Job started')
 
     return jsonify(

--- a/workers.py
+++ b/workers.py
@@ -79,7 +79,11 @@ def _inference(model: dict, data: pd.DataFrame) -> dict:
     return inf.predict()
 
 
-def prediction_worker(job: dict, next_service: str) -> Thread:
+def prediction_worker(
+        job: dict,
+        next_service: str,
+        b64_identity: str = None
+) -> Thread:
     def worker() -> None:
         thread = current_thread()
         logger.debug('%s: Worker started', thread.name)
@@ -127,7 +131,12 @@ def prediction_worker(job: dict, next_service: str) -> Thread:
         )
         # Pass to the next service
         try:
-            _retryable('post', f'http://{next_service}', json=output)
+            _retryable(
+                'post',
+                f'http://{next_service}',
+                json=output,
+                headers={"x-rh-identity": b64_identity}
+            )
         except requests.HTTPError as exception:
             logger.error(
                 '%s: Failed to pass data for "%s": %s',


### PR DESCRIPTION
With 3scale integration, we are required to pass the `x-rh-identity` value to the POST request header.

Identical changes were done in https://github.com/ManageIQ/aiops-data-collector/pull/19

@tumido Please review