### PR TITLE
Clustering metrics and MLflow experiment tracking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ oc_cluster_train:
 		--param CEPH_BUCKET=${CEPH_BUCKET}
 
 oc_run_experiment:
-	oc new-app mlflow-experiment-job --param APP_IMAGE_URI=your-application-image-name\
+	oc new-app mlflow-experiment-job --param APP_IMAGE_URI=aiops-insights-clustering\
 		--param LIMIT_CPU=4 \
 		--param LIMIT_MEM=16G \
                 --env AIOPS_TRAINING_DATE=${AIOPS_TRAINING_DATE} \

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,15 @@ oc_build_head:
 	oc start-build systems-clustering --from-archive build/HEAD.tar.gz --follow
 
 oc_cluster_train:
+	oc new-app --template systems-clustering-job \
+		--param AIOPS_TRAINING_DATE=${AIOPS_TRAINING_DATE} \
+		--param CEPH_KEY=${CEPH_KEY} \
+		--param CEPH_SECRET=${CEPH_SECRET} \
+		--param CEPH_ENDPOINT=${CEPH_ENDPOINT} \
+		--param CEPH_BUCKET=${CEPH_BUCKET}
+
+
+oc_run_experiment:
 	oc new-app mlflow-experiment-job --param APP_IMAGE_URI=your-application-image-name\
 		--param LIMIT_CPU=4 \
 		--param LIMIT_MEM=16G \

--- a/Makefile
+++ b/Makefile
@@ -8,12 +8,14 @@ oc_build_head:
 	oc start-build systems-clustering --from-archive build/HEAD.tar.gz --follow
 
 oc_cluster_train:
-	oc new-app --template systems-clustering-job \
-		--param AIOPS_TRAINING_DATE=${AIOPS_TRAINING_DATE} \
-		--param CEPH_KEY=${CEPH_KEY} \
-		--param CEPH_SECRET=${CEPH_SECRET} \
-		--param CEPH_ENDPOINT=${CEPH_ENDPOINT} \
-		--param CEPH_BUCKET=${CEPH_BUCKET}
+	oc new-app mlflow-experiment-job --param APP_IMAGE_URI=your-application-image-name\
+		--param LIMIT_CPU=4 \
+		--param LIMIT_MEM=16G \
+                --env AIOPS_TRAINING_DATE=${AIOPS_TRAINING_DATE} \
+                --env CEPH_KEY=${CEPH_KEY} \
+                --env CEPH_SECRET=${CEPH_SECRET} \
+                --env CEPH_ENDPOINT=${CEPH_ENDPOINT} \
+                --env CEPH_BUCKET=${CEPH_BUCKET}
 
 test:
 	pipenv run pytest

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,6 @@ oc_cluster_train:
 		--param CEPH_ENDPOINT=${CEPH_ENDPOINT} \
 		--param CEPH_BUCKET=${CEPH_BUCKET}
 
-
 oc_run_experiment:
 	oc new-app mlflow-experiment-job --param APP_IMAGE_URI=your-application-image-name\
 		--param LIMIT_CPU=4 \

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ To run this application on openshift, we need to create a container image for it
 To download the source code for our experiment to openshift, use the following command:
 
 ```
-    oc process mlflow-experiment-bc --param APPLICATION_NAME=your-application-name --param GIT_URI=https://github.com/ManageIQ/aiops-insights-clustering.git --param APP_FILE=app.py | oc create -f -
+    oc process mlflow-experiment-bc --param APPLICATION_NAME=aiops-insights-clustering --param GIT_URI=https://github.com/ManageIQ/aiops-insights-clustering.git | oc create -f -
 
 ```
 Building the container image can take a couple of minutes or more depending on the number of packages that need to be installed from the dependencies list.
@@ -114,13 +114,7 @@ To see if the build process has finished, run the following command:
 
 After the image is built, we can use it to run an experiment on OpenShift.
 
-Edit the following line in the Makefile to set the APP_IMAGE_URI to your application image as follows:
-
-```
-    oc new-app mlflow-experiment-job --param APP_IMAGE_URI=your-application-image-name
-```
-
-Similary, you can even set different model training parameters and variables such as the number of CPUs and memory size  as follows:
+To set different model training parameters and variables such as the number of CPUs and memory size, you can add the additional parameters under the `oc_run_experiment` task in the Makefile as follows:
 
 ```
     --param LIMIT_CPU=4 \

--- a/README.md
+++ b/README.md
@@ -1,31 +1,19 @@
 # Clustering Systems
 
 ## Running the clustering on OpenShift
+First, we need to get the application code on OpenShift. Once you have the code on openshift, you can have multiple instances of your experiment running with different parameters.
 
-First you'll load the template that has all required resources
+To run this application on openshift, we need to create a container image for it. In other words, this means that we need to download the code that we want to run on openshift. To do this a image build template should already be available in your openshift namespace.
+
+To download the source code for our experiment to openshift, use the following command:
+```
+    oc process mlflow-experiment-bc --param APPLICATION_NAME=your-application-name --param GIT_URI=https://github.com/ManageIQ/aiops-insights-clustering.git --param APP_FILE=app.py | oc create -f -
+```
+If the image build process has started you should see some output like this:
 
 ```
-❯ oc create -f ./cluster-job-template.yaml -f ./build-config-template.yaml
-template "systems-clustering-job" created
-template "systems-clustering-bc-is" created
-```
-
-Then create the BuildConfig and ImageStream
-
-```
-❯ oc new-app --template systems-clustering-bc-is
---> Deploying template "mhild-test/systems-clustering-bc-is" to project mhild-test
-
-     * With parameters:
-        * APPLICATION_NAME=systems-clustering
-        * GIT_URI=https://github.com/ManageIQ/aiops-insights-clustering.git
-
---> Creating resources ...
-    buildconfig "systems-clustering" created
-    imagestream "systems-clustering" created
---> Success
-    Use 'oc start-build systems-clustering' to start a build.
-    Run 'oc status' to view your app.
+    imagestream.image.openshift.io "your-application-name" created
+    buildconfig.build.openshift.io "your-application-name" created
 ```
 
 ## Development workflow
@@ -35,19 +23,12 @@ Copy .env file and adjust variables
 ```
 cp .env.example .env
 ```
+After the image is built, we can use it to run the clustering on OpenShift.
 
-Start a build
 
+Edit the following line in the Makefile to set the APP_IMAGE_URI to your application image as follows:
 ```
-❯ oc start-build systems-clustering
-build "systems-clustering-1" started
-```
-
-Or to push your local committed code
-
-```
-g add .
-make oc_build_head
+    oc new-app mlflow-experiment-job --param APP_IMAGE_URI=your-application-image-name\
 ```
 
 And finally you can run a job that does the clustering

--- a/README.md
+++ b/README.md
@@ -1,19 +1,31 @@
 # Clustering Systems
 
 ## Running the clustering on OpenShift
-First, we need to get the application code on OpenShift. Once you have the code on openshift, you can have multiple instances of your experiment running with different parameters.
 
-To run this application on openshift, we need to create a container image for it. In other words, this means that we need to download the code that we want to run on openshift. To do this a image build template should already be available in your openshift namespace.
-
-To download the source code for our experiment to openshift, use the following command:
-```
-    oc process mlflow-experiment-bc --param APPLICATION_NAME=your-application-name --param GIT_URI=https://github.com/ManageIQ/aiops-insights-clustering.git --param APP_FILE=app.py | oc create -f -
-```
-If the image build process has started you should see some output like this:
+First you'll load the template that has all required resources
 
 ```
-    imagestream.image.openshift.io "your-application-name" created
-    buildconfig.build.openshift.io "your-application-name" created
+❯ oc create -f ./cluster-job-template.yaml -f ./build-config-template.yaml
+template "systems-clustering-job" created
+template "systems-clustering-bc-is" created
+```
+
+Then create the BuildConfig and ImageStream
+
+```
+❯ oc new-app --template systems-clustering-bc-is
+--> Deploying template "mhild-test/systems-clustering-bc-is" to project mhild-test
+
+     * With parameters:
+        * APPLICATION_NAME=systems-clustering
+        * GIT_URI=https://github.com/ManageIQ/aiops-insights-clustering.git
+
+--> Creating resources ...
+    buildconfig "systems-clustering" created
+    imagestream "systems-clustering" created
+--> Success
+    Use 'oc start-build systems-clustering' to start a build.
+    Run 'oc status' to view your app.
 ```
 
 ## Development workflow
@@ -23,12 +35,19 @@ Copy .env file and adjust variables
 ```
 cp .env.example .env
 ```
-After the image is built, we can use it to run the clustering on OpenShift.
 
+Start a build
 
-Edit the following line in the Makefile to set the APP_IMAGE_URI to your application image as follows:
 ```
-    oc new-app mlflow-experiment-job --param APP_IMAGE_URI=your-application-image-name\
+❯ oc start-build systems-clustering
+build "systems-clustering-1" started
+```
+
+Or to push your local committed code
+
+```
+g add .
+make oc_build_head
 ```
 
 And finally you can run a job that does the clustering
@@ -58,6 +77,82 @@ Name: cluster, Length: 40162, dtype: int32
 ```
 make test
 ```
+
+## Running the MLflow experiment on OpenShift
+
+This is a two stage process:
+- The first stage is to get the application code on OpenShift.
+- The second stage is to run the experiment
+
+Once you have the code on openshift, you can have multiple instances of your experiment running with different parameters.
+
+## First Stage: Obtaining the application code on OpenShift
+
+To run this application on openshift, we need to create a container image for it. In other words, this means that we need to download the code that we want to run on openshift. To do this a image build template should already be available in your openshift namespace.
+
+To download the source code for our experiment to openshift, use the following command:
+
+```
+    oc process mlflow-experiment-bc --param APPLICATION_NAME=your-application-name --param GIT_URI=https://github.com/ManageIQ/aiops-insights-clustering.git --param APP_FILE=app.py | oc create -f -
+
+```
+Building the container image can take a couple of minutes or more depending on the number of packages that need to be installed from the dependencies list.
+
+If the image build process has started you should see some output like this:
+
+```
+    imagestream.image.openshift.io "your-application-name" created
+    buildconfig.build.openshift.io "your-application-name" created
+```
+To see if the build process has finished, run the following command:
+```
+    oc logs bc/my-mlflow-experiment
+
+```
+
+## Second Stage: Running an experiment
+
+After the image is built, we can use it to run an experiment on OpenShift.
+
+Edit the following line in the Makefile to set the APP_IMAGE_URI to your application image as follows:
+
+```
+    oc new-app mlflow-experiment-job --param APP_IMAGE_URI=your-application-image-name
+```
+
+Similary, you can even set different model training parameters and variables such as the number of CPUs and memory size  as follows:
+
+```
+    --param LIMIT_CPU=4 \
+    --param LIMIT_MEM=16G \
+
+```
+
+Finally, you can run the experiment:
+
+```
+    make oc_run_experiment
+```
+
+This should run the experiment on OpenShift with the specified values of parameters. You can view the logs of the pod created for this experiment on OpenShift. 
+
+If you want to use a different mlflow tracking server, you can use the MLFLOW_TRACKING_URI parameter to specify its address as:
+
+```
+    --param MLFLOW_TRACKING_URI=http://mlflow-server-url:5000/
+    
+```
+The MLflow runs are logged remotely to a tracking server by connecting to the URI specified. 
+
+If you know your mlflow experiment ID, you can set it with the MLFLOW_EXPERIMENT_ID environment variable.
+```
+    --env MLFLOW_EXPERIMENT_ID=2
+```
+
+This will group all the different runs of the model under one experiment ID.
+
+The MLflow Tracking Server UI lets you visualize, search and compare runs, as well as download run artifacts or metadata for analysis in other tools.
+
 
 ## Local build
 

--- a/clustering/train.py
+++ b/clustering/train.py
@@ -148,7 +148,7 @@ class Cluster:
 
         self.inertia_dict, self.models_dict = {}, {}
         for ncl in range(self.n_clusters_low, self.n_clusters_high, self.n_clusters_stepsize):
-            kmeans = KMeans(n_clusters=ncl)
+            kmeans = KMeans(n_clusters=ncl, init='k-means++')
             kmeans.fit(self.data_for_kmeans)
 
             self.inertia_dict[ncl] = kmeans.inertia_
@@ -162,7 +162,7 @@ class Cluster:
         proc_list = []
         counter = 0
         def run(data, ncl):
-            kmeans = KMeans(n_clusters=ncl)
+            kmeans = KMeans(n_clusters=ncl, init='k-means++')
             kmeans.fit(data)
 
             inertia_shared_dict[ncl] = kmeans.inertia_
@@ -226,7 +226,7 @@ class Cluster:
         if not self.n_clusters_optimal:
             raise AttributeError("Please run find_n_clusters and find_elbow to find optimal n_clusters.")
 
-        self.kmeans_optimal = KMeans(n_clusters=self.n_clusters_optimal).fit(self.data_for_kmeans)
+        self.kmeans_optimal = KMeans(n_clusters=self.n_clusters_optimal, init='k-means++').fit(self.data_for_kmeans)
 
     def interpret(self):
         if self.kmeans_optimal is None:

--- a/metric_tracking/__init__.py
+++ b/metric_tracking/__init__.py
@@ -2,6 +2,7 @@ import logging
 import storage
 
 import mlflow
+from sklearn import metrics
 
 # for a more sophisticated method have a look at
 #  https://gitlab.cee.redhat.com/mcliffor/insights_clustering/blob/master/stability_score.py
@@ -15,12 +16,13 @@ def do_tracking():
         mlflow.log_param("Date A", date_a)
         mlflow.log_param("Date B", date_b)
         calculate_score(date_a, date_b)
+        calculate_metrics(date_a,date_b)
         mlflow.end_run()
-
+    
 def calculate_score(date_a, date_b):
     cluster_a = storage.read(date_a)
     cluster_b = storage.read(date_b)
-
+    
     inverse_cluster_a = invert_cluster(cluster_a)
     inverse_cluster_b = invert_cluster(cluster_b)
 
@@ -40,7 +42,8 @@ def calculate_score(date_a, date_b):
 
         median_number_ids_in_cluster = (len(systems_a) + len(systems_b)) / 2.0
         score = number_ids_in_both / median_number_ids_in_cluster
-
+        
+        mlflow.log_metric(("number_of_ids_in_both_days for cluster_%s" cluster_id),number_ids_in_both)
         mlflow.log_metric(("cluster_stability_%s" % cluster_id), score)
         logging.info("cluster_id %i - stability score %f" % (cluster_id, score))
 
@@ -51,3 +54,37 @@ def invert_cluster(cluster):
         new_cluster[cluster_id].append(system_id)
     return new_cluster
 
+def calculate_metrics(date_a,date_b):
+    cluster_a = storage.read(date_a)
+    cluster_b = storage.read(date_b)
+    
+    #Find the list of common system ids in both the days
+    sys_ids_a = find_sys_ids(cluster_a)
+    sys_ids_b = find_sys_ids(cluster_b)
+    sys_ids_in_both = list(set(sys_ids_a).intersection(set(sys_ids_b)))
+    num_sys_ids_in_both = len(set(sys_ids_a).intersection(set(sys_ids_b)))
+    
+    #Find the cluster labels/ids for the common system ids in both days
+    labels_a, labels_b = find_labels(sys_ids_in_both,cluster_a,cluster_b)
+    
+    #Find the performance metrics such as mutual information score, fowlkes mallows score
+    mutual_info_score = metrics.mutual_info_score(labels_a, labels_b)
+    fowlkes_mallows_score = metrics.fowlkes_mallows_score(labels_a, labels_b)
+    adjusted_rand_score = metrics.adjusted_rand_score(labels_a, labels_b)
+    
+    mlflow.log_metric("total_number_of_ids_in_both_days",num_sys_ids_in_both)
+    mlflow.log_metric("mutual_info_score",mutual_info_score)
+    mlflow.log_metric("fowlkes_mallows_score",fowlkes_mallows_score)
+    mlflow.log_metric("adjusted_rand_score",adjusted_rand_score)
+    
+def find_sys_ids(cluster):
+    sys_ids = sorted(list(cluster.keys())
+    return sys_ids
+
+def find_new_labels(common_sys_ids,cluster_1,cluster_2):
+    cluster_labels_1 = []
+    cluster_labels_2 = []
+    for system_id in sorted(common_sys_ids):
+        cluster_labels_1.append(cluster_1[system_id])
+        cluster_labels_2.append(cluster_2[system_id])
+    return cluster_labels_1, cluster_labels_2

--- a/metric_tracking/__init__.py
+++ b/metric_tracking/__init__.py
@@ -22,7 +22,6 @@ def do_tracking():
 def calculate_score(date_a, date_b):
     cluster_a = storage.read(date_a)
     cluster_b = storage.read(date_b)
-    
     inverse_cluster_a = invert_cluster(cluster_a)
     inverse_cluster_b = invert_cluster(cluster_b)
 
@@ -39,7 +38,6 @@ def calculate_score(date_a, date_b):
         # TODO: only look at systems present in both runs
 
         number_ids_in_both = len(systems_a.intersection(systems_b))
-
         median_number_ids_in_cluster = (len(systems_a) + len(systems_b)) / 2.0
         score = number_ids_in_both / median_number_ids_in_cluster
         


### PR DESCRIPTION
1. Additional clustering metrics to evaluate and compare the clustering behavior of systems for two different days.   
- Modifications made to the codebase: https://github.com/ManageIQ/aiops-insights-clustering/pull/32/files#diff-d0301332bd6fef353ec35837646aa49e
- (Detailed notebook of the code can be found here: https://gitlab.cee.redhat.com/insights-aiops/modeling/blob/master/use_cases/clustering/metric_comparing.ipynb) 

2. Integrating the MLflow experiment tracking template for logging the clustering model metrics. (https://github.com/AICoE/experiment-tracking/tree/master/openshift). 
- Updated instructions in the README for running the clustering model as an mlflow job on OpenShift: https://github.com/ManageIQ/aiops-insights-clustering/pull/32/files#diff-04c6e90faac2675aa89e2176d2eec7d8
- Added a separate task in the Makefile for the mlflow experiment tracking:
https://github.com/ManageIQ/aiops-insights-clustering/pull/32/files#diff-b67911656ef5d18c4ae36cb6741b7965

(Reference: https://github.com/AICoE/experiment-tracking-template, a demo application which shows how this template is being used to run mlflow jobs on OpenShift: )